### PR TITLE
Add TALP GPU, OpenMP and derived TALP-metric Selectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,16 +224,31 @@ If CaPI is built with TALP support, the following selectors, based on TALP effic
 | has_talp_metrics                 | -           | 1               | `has_talp_metrics`                            | Selects the subset of functions that has TALP metrics attached.         |
 | talp_cycles                      | 1           | 1               | `talp_cycles(">", 1000)`                      | Selection based on number of elapsed cycles.                            |
 | talp_instructions                | 1           | 1               | `talp_instructions(">", 500000)`              | Selection based on number of executed instructions.                     |
-| talp_measurements                | 1           | 1               | `talp_measurements(">", 5)`                   | Selection based on number of performance measurements.                  |
-| talp_elapsed_time                | 1           | 1               | `talp_elapsed_time("<", 2.0e6)`               | Selection based on total elapsed time in nanoseconds.                   |
+| talp_measurements                | 1           | 1               | `talp_measurements(">", 5)`                   | Selection based on number of times a node was measured.                 |
 | talp_mpi_calls                   | 1           | 1               | `talp_mpi_calls(">=", 10)`                    | Selection based on number of MPI calls.                                 |
+| talp_omp_parallels               | 1           | 1               | `talp_omp_parallels(">=", 10)`                | Selection based on number of encountered OpenMP parallel regions        |
+| talp_omp_tasks                   | 1           | 1               | `talp_omp_tasks(">=", 10)`                    | Selection based on number of encountered OpenMP tasks                   |
+| talp_gpu_runtime_calls           | 1           | 1               | `talp_gpu_runtime_calls("<",60)`              | Selection based on number of CUDA/HIP runtime calls                     |
+| talp_elapsed_time                | 1           | 1               | `talp_elapsed_time("<", 2.0e6)`               | Selection based on total elapsed time in nanoseconds.                   |
+| talp_useful_time                 | 1           | 1               | `talp_useful_time("<", 2.0e6)`                | Selection based on total useful time in nanoseconds.                    |
 | talp_parallel_efficiency         | 1           | 1               | `talp_parallel_efficiency("<", 0.8)`          | Selection based on overall parallel efficiency (ratio between 0 and 1). |
 | talp_mpi_parallel_efficiency     | 1           | 1               | `talp_mpi_parallel_efficiency("<", 0.9)`      | Selection based on MPI parallel efficiency (ratio between 0 and 1).     |
 | talp_mpi_comm_efficiency         | 1           | 1               | `talp_mpi_comm_efficiency("<", 0.85)`         | Selection based on MPI communication efficiency.                        |
 | talp_mpi_load_balance            | 1           | 1               | `talp_mpi_load_balance("<", 0.95)`            | Selection based on MPI load balance efficiency.                         |
 | talp_mpi_load_balance_in         | 1           | 1               | `talp_mpi_load_balance_in("<", 0.9)`          | Selection based on MPI intra-node load balance.                         |
 | talp_mpi_load_balance_out        | 1           | 1               | `talp_mpi_load_balance_out("<", 0.9)`         | Selection based on MPI inter-node load balance.                         |
+| talp_omp_parallel_efficiency     | 1           | 1               | `talp_omp_parallel_efficiency("<", 0.5)`      | Selection based on OpenMP parallel efficiency (ratio between 0 and 1)   |
+| talp_omp_load_balance            | 1           | 1               | `talp_omp_load_balance("<", 0.5)`             | Selection based on OpenMP load balance                                  |
+| talp_omp_scheduling_efficiency   | 1           | 1               | `talp_omp_scheduling_efficiency("<", 0.5)`    | Selection based on OpenMP scheduling efficiency                         |
+| talp_omp_serialization_efficiency| 1           | 1               | `talp_omp_serialization_efficiency("<", 0.5)` | Selection based on OpenMP serialization efficiency                      |
+| talp_device_offload_efficiency   | 1           | 1               | `talp_device_offload_efficiency("<", 0.5)`    | Selection based on GPU offload efficiency                               |
+| talp_gpu_parallel_efficiency     | 1           | 1               | `talp_gpu_parallel_efficiency("<", 0.5)`      | Selection based on GPU parallel efficiency (ratio between 0 and 1).     |
+| talp_gpu_comm_efficiency         | 1           | 1               | `talp_gpu_comm_efficiency("<", 0.5)`          | Selection based on GPU communication efficiency                         |
+| talp_gpu_orch_efficiency         | 1           | 1               | `talp_gpu_orch_efficiency("<", 0.5)`          | Selection based on GPU orchestration efficiency                         |
 | talp_dyn_filtered                | -           | 1               | `talp_dyn_filtered`                           | Selects functions filtered dynamically during TALP run.                 |
+| talp_avg_region_duration         | 1           | 1               | `talp_avg_region_duration("<", 1e6)`          | Selection based on average elapsed nanoseconds per region invocation    |
+| talp_avg_ipc                     | 1           | 1               | `talp_avg_ipc("<", 0.5)`                      | Selection based on average useful instructions per cycle value          |
+| talp_avg_freq                    | 1           | 1               | `talp_avg_freq("<", 1e9)`                     | Selection based on average useful frequency in Herz                     |
 
 
 ### Inline compensation

--- a/src/selection/metadata/TalpMD.h
+++ b/src/selection/metadata/TalpMD.h
@@ -30,8 +30,13 @@ struct TalpMetrics {
   unsigned long num_omp_parallels;
   /*! Number of encountered OpenMP tasks combined among all processes */
   unsigned long num_omp_tasks;
+  /*! Number of executed GPU Runtime calls combined among all processes */
+  unsigned long num_gpu_runtime_calls;
   /*! Time (in nanoseconds) of the accumulated elapsed time inside the region */
   double elapsed_time;
+  /*! Time (in nanoseconds) of the accumulated CPU time of useful computation in the application */
+  double useful_time;
+  /*! Efficiency number [0.0 - 1.0] of the impact in the application's parallelization */
   float parallel_efficiency;
   /*! Efficiency number of the impact in the MPI parallelization */
   float mpi_parallel_efficiency;
@@ -51,6 +56,16 @@ struct TalpMetrics {
   float omp_scheduling_efficiency;
   /*! Efficiency lost due to OpenMP threads outside of parallel regions */
   float omp_serialization_efficiency;
+  /*! Efficiency of the Host offloading to the Device */
+  float device_offload_efficiency;
+  /*! TBD */
+  float gpu_parallel_efficiency;
+  /*! TBD */
+  float gpu_load_balance;
+  /*! TBD */
+  float gpu_communication_efficiency;
+  /*! TBD */
+  float gpu_orchestration_efficiency;
 };
 
 void to_json(nlohmann::json& j, const TalpMetrics& m) {
@@ -62,7 +77,9 @@ void to_json(nlohmann::json& j, const TalpMetrics& m) {
       {"numMpiCalls", m.num_mpi_calls},
       {"numOmpParallels", m.num_omp_parallels},
       {"numOmpTasks", m.num_omp_tasks},
+      {"numGpuRuntimeCalls", m.num_gpu_runtime_calls},
       {"elapsedTime", m.elapsed_time},
+      {"usefulTime", m.useful_time},
       {"parallelEfficiency", m.parallel_efficiency},
       {"mpiParallelEfficiency", m.mpi_parallel_efficiency},
       {"mpiCommunicationEfficiency", m.mpi_communication_efficiency},
@@ -73,28 +90,40 @@ void to_json(nlohmann::json& j, const TalpMetrics& m) {
       {"ompLoadBalance", m.omp_load_balance},
       {"ompSchedulingEfficiency", m.omp_scheduling_efficiency},
       {"ompSerializationEfficiency", m.omp_serialization_efficiency},
+      {"deviceOffloadEfficiency", m.device_offload_efficiency},
+      {"gpuParallelEfficiency", m.gpu_parallel_efficiency},
+      {"gpuLoadBalance", m.gpu_load_balance},
+      {"gpuCommunicationEfficiency", m.gpu_communication_efficiency},
+      {"gpuOrchestrationEfficiency", m.gpu_orchestration_efficiency},
   };
 }
 
 void from_json(const nlohmann::json& j, TalpMetrics& m) {
-  j.at("numCpus").get_to(m.num_cpus);
-  j.at("cycles").get_to(m.cycles);
-  j.at("instructions").get_to(m.instructions);
-  j.at("numMeasurements").get_to(m.num_measurements);
-  j.at("numMpiCalls").get_to(m.num_mpi_calls);
-  j.at("numOmpParallels").get_to(m.num_omp_parallels);
-  j.at("numOmpTasks").get_to(m.num_omp_tasks);
-  j.at("elapsedTime").get_to(m.elapsed_time);
-  j.at("parallelEfficiency").get_to(m.parallel_efficiency);
-  j.at("mpiParallelEfficiency").get_to(m.mpi_parallel_efficiency);
-  j.at("mpiCommunicationEfficiency").get_to(m.mpi_communication_efficiency);
-  j.at("mpiLoadBalance").get_to(m.mpi_load_balance);
-  j.at("mpiLoadBalanceIn").get_to(m.mpi_load_balance_in);
-  j.at("mpiLoadBalanceOut").get_to(m.mpi_load_balance_out);
-  j.at("ompParallelEfficiency").get_to(m.omp_parallel_efficiency);
-  j.at("ompLoadBalance").get_to(m.omp_load_balance);
-  j.at("ompSchedulingEfficiency").get_to(m.omp_scheduling_efficiency);
-  j.at("ompSerializationEfficiency").get_to(m.omp_serialization_efficiency);
+  m.num_cpus = j.value("numCpus", 0);
+  m.cycles = j.value("cycles", 0.0);
+  m.instructions = j.value("instructions", 0.0);
+  m.num_measurements = j.value("numMeasurements", 0u);
+  m.num_mpi_calls = j.value("numMpiCalls", 0u);
+  m.num_omp_parallels = j.value("numOmpParallels", 0u);
+  m.num_omp_tasks = j.value("numOmpTasks",0u);
+  m.num_gpu_runtime_calls = j.value("numGpuRuntimeCalls", 0u);
+  m.elapsed_time = j.value("elapsedTime", 0.0f);
+  m.useful_time = j.value("usefulTime", 0.0f);
+  m.parallel_efficiency = j.value("parallelEfficiency", 0.0f);
+  m.mpi_parallel_efficiency = j.value("mpiParallelEfficiency", 0.0f);
+  m.mpi_communication_efficiency = j.value("mpiCommunicationEfficiency", 0.0f);
+  m.mpi_load_balance = j.value("mpiLoadBalance", 0.0f);
+  m.mpi_load_balance_in = j.value("mpiLoadBalanceIn", 0.0f);
+  m.mpi_load_balance_out = j.value("mpiLoadBalanceOut", 0.0f);
+  m.omp_parallel_efficiency = j.value("ompParallelEfficiency", 0.0f);
+  m.omp_load_balance = j.value("ompLoadBalance", 0.0f);
+  m.omp_scheduling_efficiency = j.value("ompSchedulingEfficiency", 0.0f);
+  m.omp_serialization_efficiency = j.value("ompSerializationEfficiency", 0.0f);
+  m.device_offload_efficiency = j.value("deviceOffloadEfficiency", 0.0f);
+  m.gpu_parallel_efficiency = j.value("gpuParallelEfficiency", 0.0f);
+  m.gpu_load_balance = j.value("gpuLoadBalance", 0.0f);
+  m.gpu_communication_efficiency = j.value("gpuCommunicationEfficiency", 0.0f);
+  m.gpu_orchestration_efficiency = j.value("gpuOrchestrationEfficiency", 0.0f);
 }
 
 struct TalpPathMetrics {

--- a/src/selection/selectors/SelectorInstantiation.cpp
+++ b/src/selection/selectors/SelectorInstantiation.cpp
@@ -179,19 +179,33 @@ RegisterSelector caSelectorDistinct("common_caller_distinct",
 RegisterSelector iscSelector("inclusive_statement_count", createMetricSelector<ISCMetric>);
 
 // TALP metrics
-// TODO: OMP metrics not added yet
 RegisterSelector hasTalpMetrics("has_talp_metrics", createSimpleSelector<HasTalpMetricsSelector>);
 RegisterSelector cyclesSelector("talp_cycles", createMetricSelector<TalpMetric<TalpMetricKind::CYCLES, long>>);
 RegisterSelector instructionSelector("talp_instructions", createMetricSelector<TalpMetric<TalpMetricKind::INSTRUCTIONS, long>>);
 RegisterSelector numMeasurements("talp_measurements", createMetricSelector<TalpMetric<TalpMetricKind::NUM_MEASUREMENTS, long>>);
-RegisterSelector elapsedTimeSelector("talp_elapsed_time", createMetricSelector<TalpMetric<TalpMetricKind::ELAPSED_TIME, long>>);
 RegisterSelector numMpiCallSelector("talp_mpi_calls", createMetricSelector<TalpMetric<TalpMetricKind::NUM_MPI_CALLS,long>>);
+RegisterSelector numOMPParallelsSelector("talp_omp_parallels", createMetricSelector<TalpMetric<TalpMetricKind::NUM_OMP_PARALLELS,long>>);
+RegisterSelector numOMPTasksSelector("talp_omp_tasks", createMetricSelector<TalpMetric<TalpMetricKind::NUM_OMP_TASKS,long>>);
+RegisterSelector numGPURuntimeCallsSelector("talp_gpu_runtime_calls", createMetricSelector<TalpMetric<TalpMetricKind::NUM_GPU_RUNTIME_CALLS,long>>);
+RegisterSelector elapsedTimeSelector("talp_elapsed_time", createMetricSelector<TalpMetric<TalpMetricKind::ELAPSED_TIME, double>>);
+RegisterSelector usefulTimeSelector("talp_useful_time", createMetricSelector<TalpMetric<TalpMetricKind::USEFUL_TIME, double>>);
 RegisterSelector parEffSelector("talp_parallel_efficiency", createMetricSelector<TalpMetric<TalpMetricKind::PARALLEL_EFFICIENCY, float>>);
 RegisterSelector mpiParEffSelector("talp_mpi_parallel_efficiency", createMetricSelector<TalpMetric<TalpMetricKind::MPI_PARALLEL_EFFICIENCY, float>>);
 RegisterSelector mpiCommEffSelector("talp_mpi_comm_efficiency", createMetricSelector<TalpMetric<TalpMetricKind::MPI_COMMUNICATION_EFFICIENCY, float>>);
 RegisterSelector mpiLoadBalanceSelector("talp_mpi_load_balance", createMetricSelector<TalpMetric<TalpMetricKind::MPI_LOAD_BALANCE, float>>);
 RegisterSelector mpiLoadBalanceInSelector("talp_mpi_load_balance_in", createMetricSelector<TalpMetric<TalpMetricKind::MPI_LOAD_BALANCE_IN, float>>);
 RegisterSelector mpiLoadBalanceOutSelector("talp_mpi_load_balance_out", createMetricSelector<TalpMetric<TalpMetricKind::MPI_LOAD_BALANCE_OUT, float>>);
+RegisterSelector ompParEffSelector("talp_omp_parallel_efficiency", createMetricSelector<TalpMetric<TalpMetricKind::OMP_PARALLEL_EFFICIENCY, float>>);
+RegisterSelector ompLoadBalanceSelector("talp_omp_load_balance", createMetricSelector<TalpMetric<TalpMetricKind::OMP_LOAD_BALANCE, float>>);
+RegisterSelector ompSchedulingSelector("talp_omp_scheduling_efficiency", createMetricSelector<TalpMetric<TalpMetricKind::OMP_SCHEDULING_EFFICIENCY, float>>);
+RegisterSelector ompSerializationSelector("talp_omp_serialization_efficiency", createMetricSelector<TalpMetric<TalpMetricKind::OMP_SERIALIZATION_EFFICIENCY, float>>);
+RegisterSelector deviceOffloadSelector("talp_device_offload_efficiency", createMetricSelector<TalpMetric<TalpMetricKind::DEVICE_OFFLOAD_EFFICIENCY, float>>);
+RegisterSelector gpuParallelEffSelector("talp_gpu_parallel_efficiency", createMetricSelector<TalpMetric<TalpMetricKind::GPU_PARALLEL_EFFICIENCY, float>>);
+RegisterSelector gpuCommEffSelector("talp_gpu_comm_efficiency", createMetricSelector<TalpMetric<TalpMetricKind::GPU_COMMUNICATION_EFFICIENCY, float>>);
+RegisterSelector gpuOrchEffSelector("talp_gpu_orch_efficiency", createMetricSelector<TalpMetric<TalpMetricKind::GPU_ORCHESTRATION_EFFICIENCY, float>>);
+RegisterSelector averageRegionDurationSelector("talp_avg_region_duration", createMetricSelector<TalpMetric<TalpMetricKind::AVERAGE_REGION_DURATION, float>>);
+RegisterSelector averageIPCSelector("talp_avg_ipc", createMetricSelector<TalpMetric<TalpMetricKind::AVERAGE_IPC, float>>);
+RegisterSelector averageFREQSelector("talp_avg_freq", createMetricSelector<TalpMetric<TalpMetricKind::AVERAGE_FREQ, float>>);
 RegisterSelector dynFilteredSelector("talp_dyn_filtered", createSimpleSelector<TalpDynFilteredSelector>);
 
 using IPCMetric = DerivedMetric<TalpMetric<capi::TalpMetricKind::INSTRUCTIONS, long>, TalpMetric<capi::TalpMetricKind::CYCLES, long>, double, ddivl>;

--- a/src/selection/selectors/TalpMetricSelector.h
+++ b/src/selection/selectors/TalpMetricSelector.h
@@ -18,7 +18,9 @@ enum class TalpMetricKind {
   NUM_MPI_CALLS,
   NUM_OMP_PARALLELS,
   NUM_OMP_TASKS,
+  NUM_GPU_RUNTIME_CALLS,
   ELAPSED_TIME,
+  USEFUL_TIME,
   PARALLEL_EFFICIENCY,
   MPI_PARALLEL_EFFICIENCY,
   MPI_COMMUNICATION_EFFICIENCY,
@@ -28,7 +30,17 @@ enum class TalpMetricKind {
   OMP_PARALLEL_EFFICIENCY,
   OMP_LOAD_BALANCE,
   OMP_SCHEDULING_EFFICIENCY,
-  OMP_SERIALIZATION_EFFICIENCY
+  OMP_SERIALIZATION_EFFICIENCY,
+  // GPU metrics
+  DEVICE_OFFLOAD_EFFICIENCY,
+  GPU_PARALLEL_EFFICIENCY,
+  GPU_LOAD_BALANCE,
+  GPU_COMMUNICATION_EFFICIENCY,
+  GPU_ORCHESTRATION_EFFICIENCY,
+  // Derived metrics
+  AVERAGE_REGION_DURATION,
+  AVERAGE_IPC,
+  AVERAGE_FREQ,
 };
 
 /**
@@ -54,8 +66,12 @@ double lookupMetric(const TalpMetrics& metrics) {
       return metrics.num_omp_parallels;
     case TalpMetricKind::NUM_OMP_TASKS:
       return metrics.num_omp_tasks;
+    case TalpMetricKind::NUM_GPU_RUNTIME_CALLS:
+      return metrics.num_gpu_runtime_calls;
     case TalpMetricKind::ELAPSED_TIME:
       return metrics.elapsed_time;
+    case TalpMetricKind::USEFUL_TIME:
+      return metrics.useful_time;
     case TalpMetricKind::PARALLEL_EFFICIENCY:
       return metrics.parallel_efficiency;
     case TalpMetricKind::MPI_PARALLEL_EFFICIENCY:
@@ -76,6 +92,25 @@ double lookupMetric(const TalpMetrics& metrics) {
       return metrics.omp_scheduling_efficiency;
     case TalpMetricKind::OMP_SERIALIZATION_EFFICIENCY:
       return metrics.omp_serialization_efficiency;
+    case TalpMetricKind::DEVICE_OFFLOAD_EFFICIENCY:
+      return metrics.device_offload_efficiency;
+    case TalpMetricKind::GPU_PARALLEL_EFFICIENCY:
+      return metrics.gpu_parallel_efficiency;
+    case TalpMetricKind::GPU_LOAD_BALANCE:
+      return metrics.gpu_load_balance;
+    case TalpMetricKind::GPU_COMMUNICATION_EFFICIENCY:
+      return metrics.gpu_communication_efficiency;
+    case TalpMetricKind::GPU_ORCHESTRATION_EFFICIENCY:
+      return metrics.gpu_orchestration_efficiency;
+    case TalpMetricKind::AVERAGE_REGION_DURATION:
+      if(metrics.num_measurements == 0) return 0.0f;
+      return metrics.elapsed_time / metrics.num_measurements;
+    case TalpMetricKind::AVERAGE_IPC:
+      if (metrics.cycles == 0.0f) return 0.0f;
+      return metrics.instructions / metrics.cycles;
+    case TalpMetricKind::AVERAGE_FREQ:
+      if (metrics.cycles == 0.0f) return 0.0f;
+      return metrics.cycles / metrics.useful_time;
     default:
       break;
   }

--- a/src/selection/selectors/TalpMetricSelector.h
+++ b/src/selection/selectors/TalpMetricSelector.h
@@ -106,10 +106,10 @@ double lookupMetric(const TalpMetrics& metrics) {
       if(metrics.num_measurements == 0) return 0.0f;
       return metrics.elapsed_time / metrics.num_measurements;
     case TalpMetricKind::AVERAGE_IPC:
-      if (metrics.cycles == 0.0f) return 0.0f;
+      if (metrics.cycles == 0.0f || metrics.instructions == 0.0f) return 0.0f;
       return metrics.instructions / metrics.cycles;
     case TalpMetricKind::AVERAGE_FREQ:
-      if (metrics.cycles == 0.0f) return 0.0f;
+      if (metrics.cycles == 0.0f || metrics.useful_time == 0.0f) return 0.0f;
       return metrics.cycles / metrics.useful_time;
     default:
       break;


### PR DESCRIPTION
I extended the TALP Metadata to also read and write the GPU metrics introduced in TALP 3.6.0, 
As well as introducing a few derived metrics. 

@sebastiankreutzer 
I implemented the derived metrics a bit differently as i was not sure what happens to the division by zero when i use the `DerivedMetric`. Let me know if should just move them to the an actual `DerivedMetric`  :)

- [x] Document the new selectors in readme
